### PR TITLE
#69 refactor: 수면 테스트 부분 공통 Layout 컴포넌트 사용하여 수정 및 공통 Layout 컴포넌트 일부 수정

### DIFF
--- a/frontend-app/src/app/test/SleepTest.tsx
+++ b/frontend-app/src/app/test/SleepTest.tsx
@@ -1,7 +1,6 @@
 import {
   View,
   Text,
-  Image,
   Animated,
   StyleSheet,
   ScrollView,
@@ -9,9 +8,9 @@ import {
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
-import { LinearGradient } from 'expo-linear-gradient';
 import { GlassCard } from '@/components/common/Card';
 import { Button } from '@/components/common/Button';
+import { Layout } from '@/components/common/Layout';
 import { colors } from '@/constants/colors';
 import { RootStackParamList } from '@/App';
 import { useEffect, useRef } from 'react';
@@ -47,18 +46,9 @@ export default function SleepTestDesc() {
   }
 
   return (
-    <LinearGradient
-      colors={[colors.softBlue, colors.white]}
-      style={styles.gradient}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 0, y: 1 }}
-    >
+    <Layout>
       <ScrollView contentContainerStyle={styles.scrollContainer}>
         <View style={styles.root}>
-          <Image
-            source={require('@/assets/focuz_name_logo.png')}
-            style={styles.nameLogoImage}
-          />
           <GlassCard style={[styles.container, { width: containerWidth }]}>
             <Text style={styles.title}> 현재 인지 능력 측정하기 </Text>
             <View style={styles.imageContainer}>
@@ -92,20 +82,16 @@ export default function SleepTestDesc() {
           </GlassCard>
         </View>
       </ScrollView>
-    </LinearGradient>
+    </Layout>
   );
 }
 
 const styles = StyleSheet.create({
-  gradient: {
-    flex: 1,
-  },
   scrollContainer: {
     flexGrow: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    paddingTop: 50,
-    paddingBottom: 100,
+    paddingTop: 10,
   },
   root: {
     flex: 1,
@@ -116,6 +102,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     padding: 30,
+    marginBottom: 10,
     gap: 50,
   },
   title: {
@@ -151,11 +138,6 @@ const styles = StyleSheet.create({
   logoImage: {
     width: 200,
     height: 150,
-  },
-  nameLogoImage: {
-    width: 100,
-    height: 20,
-    marginBottom: 30,
   },
   button: {
     width: 130,

--- a/frontend-app/src/app/test/SleepTestMain.tsx
+++ b/frontend-app/src/app/test/SleepTestMain.tsx
@@ -1,9 +1,8 @@
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
-import { LinearGradient } from 'expo-linear-gradient';
+import { Layout } from '@/components/common/Layout';
 import { View, StyleSheet } from 'react-native';
 import { Text } from '@/components/common/Text';
-import { colors } from '@/constants/colors';
 import { RootStackParamList } from '@/App';
 import { useEffect } from 'react';
 
@@ -15,17 +14,11 @@ export default function SleepTestMain() {
     const timeOut = setTimeout(() => {
       navigation.navigate('SleepTestDesc');
     }, 2000);
-
     return () => clearTimeout(timeOut);
   }, []);
 
   return (
-    <LinearGradient
-      colors={[colors.softBlue, colors.white]}
-      style={styles.gradient}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 0, y: 1 }}
-    >
+    <Layout showLogo={false}>
       <View style={styles.mainBox}>
         <Text variant="displayMedium" style={styles.title}>
           FOCUZ
@@ -34,16 +27,11 @@ export default function SleepTestMain() {
           수면 테스트를 진행합니다.
         </Text>
       </View>
-    </LinearGradient>
+    </Layout>
   );
 }
 
 const styles = StyleSheet.create({
-  gradient: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
   title: {
     fontWeight: 'bold',
   },

--- a/frontend-app/src/app/test/SleepTestResult.tsx
+++ b/frontend-app/src/app/test/SleepTestResult.tsx
@@ -1,16 +1,15 @@
 import {
   View,
   Text,
-  Image,
   StyleSheet,
   ScrollView,
   useWindowDimensions,
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import ResultChart from '@/components/chart/ResultChart';
-import { LinearGradient } from 'expo-linear-gradient';
 import { GlassCard } from '@/components/common/Card';
 import { Button } from '@/components/common/Button';
+import { Layout } from '@/components/common/Layout';
 import { useNavigation } from 'expo-router';
 import { colors } from '@/constants/colors';
 import { RootStackParamList } from '@/App';
@@ -30,18 +29,9 @@ export default function SleepTestResult() {
   }
 
   return (
-    <LinearGradient
-      colors={[colors.softBlue, colors.white]}
-      style={styles.gradient}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 0, y: 1 }}
-    >
+    <Layout>
       <ScrollView contentContainerStyle={styles.scrollContainer}>
         <View style={styles.root}>
-          <Image
-            source={require('@/assets/focuz_name_logo.png')}
-            style={styles.nameLogoImage}
-          />
           <GlassCard style={[styles.container, { width: containerWidth }]}>
             <Text style={styles.mainTitle}> 수면 테스트 측정 완료 </Text>
             <ResultChart />
@@ -104,29 +94,21 @@ export default function SleepTestResult() {
           </GlassCard>
         </View>
       </ScrollView>
-    </LinearGradient>
+    </Layout>
   );
 }
 
 const styles = StyleSheet.create({
-  gradient: {
-    flex: 1,
-  },
   scrollContainer: {
     flexGrow: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    paddingTop: 40,
-    paddingBottom: 100,
+    paddingTop: 10,
+    paddingBottom: 50,
   },
   root: {
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  nameLogoImage: {
-    width: 100,
-    height: 20,
-    marginBottom: 10,
   },
   container: {
     justifyContent: 'space-evenly',

--- a/frontend-app/src/components/common/Layout.tsx
+++ b/frontend-app/src/components/common/Layout.tsx
@@ -9,22 +9,35 @@ import Modal from '@/components/common/Modal';
 // Layout 컴포넌트의 props 타입 정의
 interface LayoutProps {
   children: React.ReactNode; // 레이아웃 내부에 들어갈 자식 요소
+  showLogo?: boolean;
 }
 
 // Layout: 화면 전체를 감싸는 공통 레이아웃 컴포넌트
-export const Layout: React.FC<LayoutProps> = ({ children }) => {
+export const Layout: React.FC<LayoutProps> = ({
+  children,
+  showLogo = true,
+}) => {
   return (
-    // SafeAreaView: 노치/엣지 등 안전 영역 보장
-    <SafeAreaView style={styles.container} edges={['top', 'bottom', 'left', 'right']}>
-      <LinearGradient
-        colors={[colors.softBlue, colors.white]}
-        style={styles.gradient}
-        start={{ x: 0, y: 0 }}
-        end={{ x: 0, y: 1 }}
+    <LinearGradient
+      colors={[colors.softBlue, colors.white]}
+      style={styles.gradient}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 0, y: 1 }}
+    >
+      {/* SafeAreaView: 노치/엣지 등 안전 영역 보장 */}
+      <SafeAreaView
+        style={styles.container}
+        edges={['top', 'bottom', 'left', 'right']}
       >
-        <View style={styles.logoContainer}>
-          <Image source={require('@/assets/focuz_name_logo.png')} style={styles.logo} resizeMode="contain" />
-        </View>
+        {showLogo && (
+          <View style={styles.logoContainer}>
+            <Image
+              source={require('@/assets/focuz_name_logo.png')}
+              style={styles.logo}
+              resizeMode="contain"
+            />
+          </View>
+        )}
         <View style={styles.content}>{children}</View>
         <Navbar />
         <Modal type="success" />
@@ -32,8 +45,8 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
         <Modal type="warning" />
         <Modal type="info" />
         <Modal type="confirm" />
-      </LinearGradient>
-    </SafeAreaView>
+      </SafeAreaView>
+    </LinearGradient>
   );
 };
 
@@ -56,7 +69,7 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
-    padding: 16,
+    padding: 10,
     paddingBottom: 80, // 네비게이션 바 높이(64) + 여유 공간(16)
   },
 });

--- a/frontend-app/src/components/sleepTest/SleepTest1.tsx
+++ b/frontend-app/src/components/sleepTest/SleepTest1.tsx
@@ -9,11 +9,10 @@ import {
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
-import { LinearGradient } from 'expo-linear-gradient';
-import { colors } from '@/constants/colors';
 import { RootStackParamList } from '@/App';
 import { GlassCard } from '../common/Card';
 import { Button } from '../common/Button';
+import { Layout } from '../common/Layout';
 
 const MAX_STEP = 5;
 const MIN_WAIT_TIME = 1000;
@@ -35,9 +34,9 @@ export default function SleepTest1() {
   const { height: windowHeight } = useWindowDimensions();
   const { width: windowWidth } = useWindowDimensions();
 
-  const containerHeight = Math.min(windowHeight * 0.8, 1000);
+  const containerHeight = Math.min(windowHeight * 0.75, 1000);
   const containerWidth = Math.min(windowWidth * 0.9, 700);
-  const circlerWidth = Math.min(windowWidth * 0.3, 220);
+  const circlerWidth = Math.min(windowWidth * 0.3, 180);
 
   function goToSleepTest2Desc() {
     navigation.navigate('SleepTest2Desc');
@@ -114,19 +113,10 @@ export default function SleepTest1() {
   const commaAllClickTimeAvg = allClickTimeAvg.toLocaleString();
 
   return (
-    <LinearGradient
-      colors={[colors.softBlue, colors.white]}
-      style={styles.gradient}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 0, y: 1 }}
-    >
+    <Layout>
       <View style={styles.container}>
         {isFinished ? (
           <View style={styles.resultBox}>
-            <Image
-              source={require('@/assets/focuz_name_logo.png')}
-              style={styles.nameLogoImage}
-            />
             <Image
               source={require('@/assets/result.png')}
               style={styles.resultImage}
@@ -148,10 +138,6 @@ export default function SleepTest1() {
           </View>
         ) : (
           <>
-            <Image
-              source={require('@/assets/focuz_name_logo.png')}
-              style={styles.nameLogoImage}
-            />
             <GlassCard
               style={[
                 styles.secContainer,
@@ -205,14 +191,11 @@ export default function SleepTest1() {
           </>
         )}
       </View>
-    </LinearGradient>
+    </Layout>
   );
 }
 
 const styles = StyleSheet.create({
-  gradient: {
-    flex: 1,
-  },
   container: {
     flex: 1,
     alignItems: 'center',
@@ -221,6 +204,7 @@ const styles = StyleSheet.create({
   secContainer: {
     justifyContent: 'space-evenly',
     alignItems: 'center',
+    marginTop: 10,
     padding: 30,
     paddingHorizontal: 20,
     gap: 25,
@@ -233,7 +217,7 @@ const styles = StyleSheet.create({
   },
   testBox: {
     alignItems: 'center',
-    gap: 60,
+    gap: 40,
   },
   progress: {
     fontSize: 20,
@@ -320,11 +304,6 @@ const styles = StyleSheet.create({
   msBox: {
     height: 30,
     marginTop: 30,
-  },
-  nameLogoImage: {
-    width: 100,
-    height: 20,
-    marginBottom: 10,
   },
   resultImage: {
     width: 100,

--- a/frontend-app/src/components/sleepTest/SleepTest1Desc.tsx
+++ b/frontend-app/src/components/sleepTest/SleepTest1Desc.tsx
@@ -1,19 +1,17 @@
 import {
   View,
   Text,
-  Image,
   Animated,
   StyleSheet,
   useWindowDimensions,
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
-import { LinearGradient } from 'expo-linear-gradient';
 import { Button } from '@/components/common/Button';
-import { colors } from '@/constants/colors';
 import { GlassCard } from '../common/Card';
 import { RootStackParamList } from '@/App';
 import { useEffect, useRef } from 'react';
+import { Layout } from '../common/Layout';
 
 export default function SleepTest1Desc() {
   const navigation =
@@ -55,17 +53,8 @@ export default function SleepTest1Desc() {
   });
 
   return (
-    <LinearGradient
-      colors={[colors.softBlue, colors.white]}
-      style={styles.gradient}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 0, y: 1 }}
-    >
+    <Layout>
       <View style={styles.root}>
-        <Image
-          source={require('@/assets/focuz_name_logo.png')}
-          style={styles.nameLogoImage}
-        />
         <GlassCard
           style={[
             styles.container,
@@ -93,14 +82,11 @@ export default function SleepTest1Desc() {
           />
         </GlassCard>
       </View>
-    </LinearGradient>
+    </Layout>
   );
 }
 
 const styles = StyleSheet.create({
-  gradient: {
-    flex: 1,
-  },
   root: {
     flex: 1,
     justifyContent: 'center',
@@ -151,11 +137,6 @@ const styles = StyleSheet.create({
     height: 70,
     borderRadius: 150,
     margin: 20,
-  },
-  nameLogoImage: {
-    width: 100,
-    height: 20,
-    marginBottom: 40,
   },
   button: {
     width: 70,

--- a/frontend-app/src/components/sleepTest/SleepTest2.tsx
+++ b/frontend-app/src/components/sleepTest/SleepTest2.tsx
@@ -9,11 +9,10 @@ import {
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
-import { LinearGradient } from 'expo-linear-gradient';
 import { Button } from '@/components/common/Button';
-import { colors } from '@/constants/colors';
 import { RootStackParamList } from '@/App';
 import { GlassCard } from '../common/Card';
+import { Layout } from '../common/Layout';
 
 const MAX_NUM = 9;
 const TIMER_SECOND = 60000;
@@ -46,7 +45,7 @@ export default function SleepTest2() {
   const { height: windowHeight } = useWindowDimensions();
   const { width: windowWidth } = useWindowDimensions();
 
-  const containerHeight = Math.min(windowHeight * 0.8, 1000);
+  const containerHeight = Math.min(windowHeight * 0.77, 1000);
   const containerWidth = Math.min(windowWidth * 0.9, 700);
   const symbolBoxWidth = Math.min(windowWidth * 0.8, 400);
   const lineWidth = Math.min(windowWidth * 0.8, 600);
@@ -132,19 +131,10 @@ export default function SleepTest2() {
   const commaNum = avgReactionTime.toLocaleString();
 
   return (
-    <LinearGradient
-      colors={[colors.softBlue, colors.white]}
-      style={styles.gradient}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 0, y: 1 }}
-    >
+    <Layout>
       <View style={styles.container}>
         {gameOver ? (
           <View style={styles.resultBox}>
-            <Image
-              source={require('@/assets/focuz_name_logo.png')}
-              style={styles.nameLogoImage}
-            />
             <Image
               source={require('@/assets/result.png')}
               style={styles.resultImage}
@@ -181,20 +171,18 @@ export default function SleepTest2() {
           </View>
         ) : (
           <>
-            <Image
-              source={require('@/assets/focuz_name_logo.png')}
-              style={styles.nameLogoImage}
-            />
             <GlassCard
               style={[
                 styles.secContainer,
                 { width: containerWidth, height: containerHeight },
               ]}
             >
-              <Text style={styles.title}>기호 - 숫자 변환</Text>
-              {start && !gameOver && (
-                <Text style={styles.timerText}>남은 시간: {timeLeft}s</Text>
-              )}
+              <View style={styles.titleBox}>
+                <Text style={styles.title}>기호 - 숫자 변환</Text>
+                {start && !gameOver && (
+                  <Text style={styles.timerText}>남은 시간: {timeLeft}s</Text>
+                )}
+              </View>
               <View style={[styles.line, { width: lineWidth }]} />
               <View style={[styles.symbolNumberRow, { width: symbolBoxWidth }]}>
                 {shuffledSymbols.map((symbol, idx) => (
@@ -222,27 +210,25 @@ export default function SleepTest2() {
           </>
         )}
       </View>
-    </LinearGradient>
+    </Layout>
   );
 }
 
 const styles = StyleSheet.create({
-  gradient: {
-    flex: 1,
-  },
   container: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },
   timerText: {
-    fontSize: 18,
+    fontSize: 16,
     fontWeight: 'bold',
     color: '#555',
   },
   secContainer: {
     justifyContent: 'space-evenly',
     alignItems: 'center',
+    marginTop: 10,
     padding: 30,
     paddingHorizontal: 20,
     gap: 20,
@@ -264,6 +250,10 @@ const styles = StyleSheet.create({
       height: 1,
     },
     textShadowRadius: 2,
+  },
+  titleBox: {
+    alignItems: 'center',
+    gap: 10,
   },
   line: {
     backgroundColor: '#bfbfbf',
@@ -370,11 +360,6 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: 'bold',
     color: '#0F1C36',
-  },
-  nameLogoImage: {
-    width: 100,
-    height: 20,
-    marginBottom: 10,
   },
   resultImage: {
     width: 100,

--- a/frontend-app/src/components/sleepTest/SleepTest2Desc.tsx
+++ b/frontend-app/src/components/sleepTest/SleepTest2Desc.tsx
@@ -1,19 +1,17 @@
 import {
   View,
   Text,
-  Image,
   Animated,
   StyleSheet,
   useWindowDimensions,
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
-import { LinearGradient } from 'expo-linear-gradient';
 import { Button } from '@/components/common/Button';
-import { colors } from '@/constants/colors';
 import { GlassCard } from '../common/Card';
 import { RootStackParamList } from '@/App';
 import { useEffect, useRef } from 'react';
+import { Layout } from '../common/Layout';
 
 export default function SleepTest2Desc() {
   const navigation =
@@ -55,17 +53,8 @@ export default function SleepTest2Desc() {
   });
 
   return (
-    <LinearGradient
-      colors={[colors.softBlue, colors.white]}
-      style={styles.gradient}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 0, y: 1 }}
-    >
+    <Layout>
       <View style={styles.root}>
-        <Image
-          source={require('@/assets/focuz_name_logo.png')}
-          style={styles.nameLogoImage}
-        />
         <GlassCard
           style={[
             styles.container,
@@ -96,14 +85,11 @@ export default function SleepTest2Desc() {
           />
         </GlassCard>
       </View>
-    </LinearGradient>
+    </Layout>
   );
 }
 
 const styles = StyleSheet.create({
-  gradient: {
-    flex: 1,
-  },
   root: {
     flex: 1,
     justifyContent: 'center',
@@ -149,11 +135,6 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: 'bold',
     color: '#0F1C36',
-  },
-  nameLogoImage: {
-    width: 100,
-    height: 20,
-    marginBottom: 40,
   },
   symbolBox: {
     margin: 10,

--- a/frontend-app/src/components/sleepTest/SleepTest3.tsx
+++ b/frontend-app/src/components/sleepTest/SleepTest3.tsx
@@ -8,12 +8,11 @@ import {
   useWindowDimensions,
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { LinearGradient } from 'expo-linear-gradient';
 import { useNavigation } from 'expo-router';
-import { colors } from '@/constants/colors';
 import { RootStackParamList } from '@/App';
 import { GlassCard } from '../common/Card';
 import { Button } from '../common/Button';
+import { Layout } from '../common/Layout';
 
 type RoundInfo = {
   gridSize: number;
@@ -44,9 +43,9 @@ export default function SleepTest3() {
   const { height: windowHeight } = useWindowDimensions();
   const { width: windowWidth } = useWindowDimensions();
 
-  const containerHeight = Math.min(windowHeight * 0.8, 1200);
+  const containerHeight = Math.min(windowHeight * 0.77, 1200);
   const containerWidth = Math.min(windowWidth * 0.9, 700);
-  const squareWidth = Math.min(windowWidth * 0.118, 65);
+  const squareWidth = Math.min(windowWidth * 0.118, 80);
   const lineWidth = Math.min(windowWidth * 0.8, 600);
 
   // 상태관리 객체로 수정해보기
@@ -132,18 +131,9 @@ export default function SleepTest3() {
     const answerPercent = ((totalCorrect / 18) * 100).toFixed(1);
 
     return (
-      <LinearGradient
-        colors={[colors.softBlue, colors.white]}
-        style={styles.gradient}
-        start={{ x: 0, y: 0 }}
-        end={{ x: 0, y: 1 }}
-      >
+      <Layout>
         <View style={styles.root}>
           <View style={styles.resultBox}>
-            <Image
-              source={require('@/assets/focuz_name_logo.png')}
-              style={styles.nameLogoImage}
-            />
             <Image
               source={require('@/assets/result.png')}
               style={styles.resultImage}
@@ -174,26 +164,17 @@ export default function SleepTest3() {
             />
           </View>
         </View>
-      </LinearGradient>
+      </Layout>
     );
   }
 
   const { gridSize, clickPattern } = rounds[round];
   const totalsquares = gridSize * gridSize;
-  const gridWidth = squareWidth * gridSize * 1.3;
+  const gridWidth = squareWidth * gridSize * 1.2;
 
   return (
-    <LinearGradient
-      colors={[colors.softBlue, colors.white]}
-      style={styles.gradient}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 0, y: 1 }}
-    >
+    <Layout>
       <View style={styles.root}>
-        <Image
-          source={require('@/assets/focuz_name_logo.png')}
-          style={styles.nameLogoImage}
-        />
         <GlassCard
           style={[
             styles.container,
@@ -237,14 +218,11 @@ export default function SleepTest3() {
           </View>
         </GlassCard>
       </View>
-    </LinearGradient>
+    </Layout>
   );
 }
 
 const styles = StyleSheet.create({
-  gradient: {
-    flex: 1,
-  },
   root: {
     flex: 1,
     justifyContent: 'center',
@@ -253,8 +231,8 @@ const styles = StyleSheet.create({
   container: {
     justifyContent: 'space-evenly',
     alignItems: 'center',
+    marginTop: 10,
     padding: 30,
-    paddingHorizontal: 20,
     gap: 15,
     backgroundColor: 'rgba(255, 255, 255, 0.600)',
   },
@@ -316,7 +294,7 @@ const styles = StyleSheet.create({
     marginVertical: 20,
   },
   square: {
-    margin: 5,
+    margin: 3,
     borderRadius: 6,
   },
   result: {
@@ -336,11 +314,6 @@ const styles = StyleSheet.create({
       height: 1,
     },
     textShadowRadius: 2,
-  },
-  nameLogoImage: {
-    width: 100,
-    height: 20,
-    marginBottom: 10,
   },
   resultImage: {
     width: 100,

--- a/frontend-app/src/components/sleepTest/SleepTest3Desc.tsx
+++ b/frontend-app/src/components/sleepTest/SleepTest3Desc.tsx
@@ -1,19 +1,17 @@
 import {
   View,
   Text,
-  Image,
   Animated,
   StyleSheet,
   useWindowDimensions,
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
-import { LinearGradient } from 'expo-linear-gradient';
 import { Button } from '@/components/common/Button';
-import { colors } from '@/constants/colors';
 import { GlassCard } from '../common/Card';
 import { RootStackParamList } from '@/App';
 import { useEffect, useRef } from 'react';
+import { Layout } from '../common/Layout';
 
 const SQUARE = 4;
 
@@ -57,17 +55,8 @@ export default function SleepTest3Desc() {
   });
 
   return (
-    <LinearGradient
-      colors={[colors.softBlue, colors.white]}
-      style={styles.gradient}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 0, y: 1 }}
-    >
+    <Layout>
       <View style={styles.root}>
-        <Image
-          source={require('@/assets/focuz_name_logo.png')}
-          style={styles.nameLogoImage}
-        />
         <GlassCard
           style={[
             styles.container,
@@ -104,14 +93,11 @@ export default function SleepTest3Desc() {
           />
         </GlassCard>
       </View>
-    </LinearGradient>
+    </Layout>
   );
 }
 
 const styles = StyleSheet.create({
-  gradient: {
-    flex: 1,
-  },
   root: {
     flex: 1,
     justifyContent: 'center',
@@ -165,11 +151,6 @@ const styles = StyleSheet.create({
     },
     shadowOpacity: 0.8,
     shadowRadius: 10,
-  },
-  nameLogoImage: {
-    width: 100,
-    height: 20,
-    marginBottom: 40,
   },
   squareBox: {
     flexDirection: 'row',


### PR DESCRIPTION
## 🔗 관련 이슈

#69 

## ✨ 작업 목록

- [x] 공통 컴포넌트 [ Layout ] 수정
- [x] 수면 테스트 로고 제거 및 공통 컴포넌트 적용

## ✅ 체크리스트

- [x] 코드가 정상적으로 작동하고 테스트를 통과했나요?
- [x] 스타일 가이드를 따랐나요?
- [x] PR 제목과 커밋 메시지를 명확하게 작성했나요?
- [x] 관련 이슈를 연결했나요? (예: `close #1`)

## 🙋‍♀️ 기타 참고사항(선택)

### Layout 공통 컴포넌트 수정 사항 

1. 노치(상단) 영역까지 그라데이션 적용
 •    기존에는 SafeAreaView가 최상위에 있어 상단 노치 영역에 그라데이션이 적용되지 않고 흰 배경으로 보이는 문제가 있었습니다.
 •    이를 해결하기 위해 LinearGradient를 최상위로 감싸고, 내부에 SafeAreaView를 넣는 구조로 수정했습니다.
 •    해당 구조는 React Native에서도 일반적으로 사용되는 패턴이며, SafeAreaView는 버튼/텍스트 등 요소 영역만 감싸줘도 안전하게 배치됩니다.

 •    `구조 변경`: SafeAreaView - LinearGradient →  LinearGradient - SafeAreaView


2. showLogo props 추가
 •    화면에 따라 상단 로고 이미지를 제외하고 싶은 경우가 있어, 이를 제어할 수 있도록 showLogo라는 props를 추가했습니다.
 •    기본값은 true이며, 로고가 필요 없는 화면에서는 아래와 같이 사용하시면 됩니다 !

```
<Layout showLogo={false}>
  {/* 화면 내용 */}
</Layout>
```


3. content 패딩 조정 (padding: 16 → 10)
 •    상단 로고와의 간격이 약간 멀게 느껴져 시각적으로 동떨어져 보이는 감이 있어, content 영역의 패딩을 살짝 줄였습니다.
 •    전체적인 밀착감이 개선되어 좀 더 자연스럽게 보이도록 수정하였습니다.
공통 컴포넌트 부분이라 공유 필요한 내용같아서 정리하여 공유 드립니다 ! 
