### PR TITLE
#155 fix: 수면 기록 및 테스트 점수 UI 부분 수정

### DIFF
--- a/frontend-app/src/app/tabs/HistoryDetail.tsx
+++ b/frontend-app/src/app/tabs/HistoryDetail.tsx
@@ -199,7 +199,7 @@ export const SleepRecordDetailPage: React.FC = () => {
                   평균 시간
                 </Text>
                 <Text variant="titleMedium" style={styles.testResultValue}>
-                  {pattern_time_ms}ms
+                  {pattern_time_ms}s
                 </Text>
               </View>
             </View>

--- a/frontend-app/src/app/tabs/mypage/ProfileCard.tsx
+++ b/frontend-app/src/app/tabs/mypage/ProfileCard.tsx
@@ -30,6 +30,8 @@ const ProfileCard = () => {
   const { data: mypageMain, refetch: refetchMypageMain } = useMypageMain();
   const today = new Date().toISOString().split('T')[0];
 
+  console.log(mypageMain);
+
   const { data: dayRecordData } = useSleepRecordList('day');
   const hasTodayRecord = (dayRecordData?.results as DayRecord[])?.some(
     item => item.date === today,
@@ -212,10 +214,18 @@ const ProfileCard = () => {
         </View>
         <View style={styles.averageBox}>
           <Text variant="bodyMedium" style={styles.averageLabel}>
-            평균 점수
+            수면 평균 점수
           </Text>
           <Text variant="titleMedium" style={styles.averageValue}>
             {mypageMain?.average_sleep_score ?? '-'}점
+          </Text>
+        </View>
+        <View style={styles.averageBox}>
+          <Text variant="bodyMedium" style={styles.averageLabel}>
+            인지 평균 점수
+          </Text>
+          <Text variant="titleMedium" style={styles.averageValue}>
+            {mypageMain?.average_cognitive_score ?? '-'}점
           </Text>
         </View>
       </Card>


### PR DESCRIPTION
## 🔗 관련 이슈

#155

## ✨ 작업 목록

- [ ] 마이페이지 상단 카드 테스트 점수 추가
- [ ] 수면 기록 일자별 상세 패턴 시간 s 단위로 변경

## ✅ 체크리스트

- [ ] 코드가 정상적으로 작동하고 테스트를 통과했나요?
- [ ] 스타일 가이드를 따랐나요?
- [ ] PR 제목과 커밋 메시지를 명확하게 작성했나요?
- [ ] 관련 이슈를 연결했나요? (예: `close #1`)

## 🙋‍♀️ 기타 참고사항(선택)

- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요.